### PR TITLE
Mate alns

### DIFF
--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -41,9 +41,10 @@ GSamWriter* removed_outfile=NULL;
 bool remove_mate=false;
 bool verbose=false;
 std::unordered_map<std::string, int> ht;
-int num_mated_removed=0;
+int num_mates_removed=0;
 int num_spur_removed=0;
 int num_alns_output=0;
+int num_spur_alns_both_mates=0;
 
 struct CJunc {
     int start, end;
@@ -144,11 +145,11 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
                     if (removed_outfile != NULL) {
                         removed_outfile -> write(item->r);
                     }
-                    continue;  //escape for loop because alignment has been found
+                    break;  //escape for loop because alignment has been found
                 }
-            } 
+            }
             if (found) {
-                continue; //alignment found, skip to next brec
+                continue; //resume while loop (otherwise will be written to outfile)
             }
         }
 
@@ -164,30 +165,23 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
                                                                 brec.get_b()->core.mpos, brec.get_b()->core.pos);
         auto it_rem = removed_brecs.find(mate_key);
         if (it_rem != removed_brecs.end()) {
-            int num_rem = it_rem->second.size(); //count of mates that need to be unpaired or removed:
+            int num_rem = it_rem->second.size(); 
             bool update_flag = true;
+            //if more then 1 mate needs to be removed, check how many mates have already been unpaired:
             if (num_rem > 1) {
-                //check how many mates have already been unpaired:
-                auto it_mts = mates_unpaired.find(mate_key);
-                int num_mts = it_mts->second; 
+                int &num_mts = mates_unpaired[mate_key]; //if not seen, defaults to 0
                 if (num_mts == num_rem) {
-                    update_flag = false; //if all mates have been unpaired, do not update flag
+                    update_flag = false; // all mates have been unpaired
                 } else {
-                    //add mate_key to mates_unpaired (to keep track of removed mates):
-                    if (mates_unpaired.find(mate_key) == mates_unpaired.end()) {
-                        mates_unpaired[mate_key] = 1;
-                    } else {
-                        int val = mates_unpaired[mate_key];
-                        val++;
-                        mates_unpaired[mate_key] = val;
-                    }
-                }
+                    num_mts++;
+                } 
             }
-            //write to outfile if remove_mate is true
+
+            //write to removed_outfile if remove_mate is true
             if (update_flag && remove_mate) {
                 if (removed_outfile != NULL) {
                     removed_outfile->write(&brec);
-                    num_mated_removed++;
+                    num_mates_removed++;
                 }
                 continue;
             }
@@ -330,7 +324,7 @@ int main(int argc, char *argv[]) {
 
     if (verbose) {
         if (removed_outfile != NULL && remove_mate) {
-            std::cout << "Mates of spliced alignments removed: " << num_mated_removed << std::endl;
+            std::cout << "Mates of spliced alignments removed: " << num_mates_removed << std::endl;
         }
         std::cout << "Alignments written to output: " << num_alns_output << std::endl;
         std::cout << "Cleaning completed in: " << duration_vacuum.count() << " second(s)" << std::endl;

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -55,18 +55,18 @@ struct CJunc {
         return (start==a.start && end==a.end && strcmp(chr, a.chr) == 0);
     }
 
-    // bool operator<(const CJunc& a) {
-    //     int chr_cmp = strcmp(chr, a.chr);
-    //     if (chr_cmp == 0) {
-    //         if (start == a.start) {
-    //             return (end < a.end);
-    //         } else {
-    //             return (start < a.start);
-    //         }
-    //     } else {
-    //         return (chr_cmp < 0); //lexicoographic order
-    //     }
-    // }
+    bool operator<(const CJunc& a) {
+        int chr_cmp = strverscmp(chr, a.chr);
+        if (chr_cmp == 0) {
+            if (start == a.start) {
+                return (end < a.end);
+            } else {
+                return (start < a.start);
+            }
+        } else {
+            return (chr_cmp < 0); //version order 
+        }
+    }
 };
 
 

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -57,7 +57,11 @@ struct CJunc {
         int chr_cmp = strverscmp(chr, a.chr);
         if (chr_cmp == 0) {
             if (start == a.start) {
-                return (end < a.end);
+                if (end == a.end) {
+                    return (strand < a.strand);
+                } else {
+                    return (end < a.end);
+                }
             } else {
                 return (start < a.start);
             }
@@ -134,16 +138,12 @@ void filter_bam(GSamReader &bamreader, int unmapped, GSamWriter* outfile, GSamWr
 
 
     while (bamreader.next(brec)) {
-        bool brec_to_outfile = true;
-
         if (brec.isUnmapped()) {
             continue;
         }
-        
+
         std::tuple<std::string, std::string, int, int> key = std::make_tuple(brec.name(), brec.refName(), 
                                                             brec.get_b()->core.pos, brec.get_b()->core.mpos);
-        
-        
         auto it = removed_brecs.find(key);
         if (it != removed_brecs.end()) {
             for (PBRec* item : it->second) {
@@ -161,8 +161,6 @@ void filter_bam(GSamReader &bamreader, int unmapped, GSamWriter* outfile, GSamWr
         if (!brec.isPaired()) {
             continue;
         }
-
-
 
         std::tuple<std::string, std::string, int, int> mate_key = std::make_tuple(brec.name(), brec.refName(),
                                                                 brec.get_b()->core.mpos, brec.get_b()->core.pos);

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -158,19 +158,21 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
                 bam1_t* in_rec = brec.get_b();
                 bam1_t* rm_rec = item->r->get_b();
                 if( check_identical_cigar(in_rec, rm_rec) ) { 
+                    processed = true;
                     if (removed_outfile != NULL) {
                         removed_outfile -> write(item->r);
-                        processed = true;
-                    }   
+                    }
+                    continue;   
                 }
             } 
             if (processed) {
                 continue;
-        }
+            }
         }
 
 
         if (!brec.isPaired()) {
+            outfile->write(&brec);
             continue;
         }
 
@@ -187,7 +189,6 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
                 int num_mts = it_mts->second; 
                 if (num_mts == num_rem) {
                     update_flag = false;
-                    // break;
                 }
 
                 //add mate_key to mates_unpaired:
@@ -200,7 +201,7 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
                 }
             }
 
-            if (remove_mate) {
+            if (update_flag && remove_mate) {
                 if (removed_outfile != NULL) {
                     removed_outfile->write(&brec);
                 }

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -201,7 +201,9 @@ void filter_bam(GSamWriter* outfile, GSamWriter* removed_outfile,
             }
 
             if (remove_mate) {
-                removed_outfile->write(&brec);
+                if (removed_outfile != NULL) {
+                    removed_outfile->write(&brec);
+                }
                 continue;
             }
 

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -229,8 +229,10 @@ int main(int argc, char *argv[]) {
 
     auto start_vacuum=std::chrono::high_resolution_clock::now();
     if (verbose) {
-        std::cout << "brrrm! Flagging alignment records for removal" << std::endl;
-        std::cout << "Running vacuum on input bam file:\t" << inbamname.chars() << std::endl;
+        std::cout << std::endl;
+        std::cout << "brrrm! Vacuuming BAM file debris" << std::endl;
+        std::cout << std::endl;
+        std::cout << "Identifying alignments for removal..." << std::endl;
     }
     
     int num_alignments = 0;
@@ -297,10 +299,10 @@ int main(int argc, char *argv[]) {
     auto duration_flagging = std::chrono::duration_cast<std::chrono::seconds>(end_flagging - start_flagging).count();
 
     if (verbose) {
-        std::cout << "Flagging alignments for removal completed in (seconds):\t" << duration_flagging << std::endl;
-        std::cout << "Number of alignments flagged for removal:\t" << num_removed_spliced << std::endl;
-        std::cout << "Number of spliced alignments:\t" << num_total_spliced << std::endl;
-        std::cout << "Total number of alignments seen while vacuuming:\t" << num_alignments << std::endl;
+        std::cout << "Alignment removal identification completed in: " << duration_flagging << " second(s)" << std::endl;
+        std::cout << "Alignments flagged for removal: " << num_removed_spliced << std::endl;
+        std::cout << "Spliced alignments identified: " << num_total_spliced << std::endl;
+        std::cout << "Total alignments processed: " << num_alignments << std::endl;
     }
 
 
@@ -317,8 +319,9 @@ int main(int argc, char *argv[]) {
     auto duration_vacuum = std::chrono::duration_cast<std::chrono::seconds>(end_vacuum - start_vacuum);
 
     if (verbose) {
-        std::cout << "Vacuuming completed in (seconds):\t" << duration_vacuum.count() << std::endl;
-        std::cout << "All clear! Your vacuumed BAM file is now optimized for further analysis." << std::endl;
+        std::cout << "Cleaning completed in: " << duration_vacuum.count() << " second(s)" << std::endl;
+        std::cout << std::endl;
+        std::cout << "Congratulations! Your vacuumed BAM file is now optimized for analysis." << std::endl;
     }
 }
 
@@ -366,6 +369,7 @@ void processOptions(int argc, char* argv[]) {
 
     verbose=(args.getOpt("verbose")!=NULL || args.getOpt('V')!=NULL);
     if (verbose) {
+        std::cout << std::endl;
         fprintf(stderr, "Running Vacuum " VERSION ". Command line:\n");
         args.printCmdLine(stderr);
     }

--- a/src/vacuum.cpp
+++ b/src/vacuum.cpp
@@ -54,18 +54,19 @@ struct CJunc {
     bool operator==(const CJunc& a) {
         return (start==a.start && end==a.end && strcmp(chr, a.chr) == 0);
     }
-    bool operator<(const CJunc& a) {
-        int chr_cmp = strcmp(chr, a.chr);
-        if (chr_cmp == 0) {
-            if (start == a.start) {
-                return (end < a.end);
-            } else {
-                return (start < a.start);
-            }
-        } else {
-            return (chr_cmp < 0);
-        }
-    }
+
+    // bool operator<(const CJunc& a) {
+    //     int chr_cmp = strcmp(chr, a.chr);
+    //     if (chr_cmp == 0) {
+    //         if (start == a.start) {
+    //             return (end < a.end);
+    //         } else {
+    //             return (start < a.start);
+    //         }
+    //     } else {
+    //         return (chr_cmp < 0); //lexicoographic order
+    //     }
+    // }
 };
 
 
@@ -92,8 +93,8 @@ void loadBed(GStr inbedname) {
             gline=tmp;
             cnt++;
         }
-        char* chrname =junc[0].detach();
-        char chr = chrname[strlen(chrname) - 1];
+        char* chr =junc[0].detach();
+        //char chr = chrname[strlen(chrname) - 1];
         CJunc j(junc[1].asInt(), junc[2].asInt(), *junc[5].detach(), chr);
         spur_juncs.Add(j);
     }
@@ -144,13 +145,13 @@ int main(int argc, char *argv[]) {
 
         if (brec.exons.Count() > 1) {
             const char* chrn=brec.refName();
-            //char chr = chrname[strlen(chrname) - 1]; //TODO -> ask Hayden
             char strand = brec.spliceStrand();
             bool spur = false;
             for (int i = 1; i < brec.exons.Count(); i++) {
                 CJunc j(brec.exons[i-1].end, brec.exons[i].start-1, strand, chr);
                 if (spur_juncs.Exists(j)) {
                     spur = true;
+                    spur_cnt++;
                     break;
                 }
             }


### PR DESCRIPTION
Added new features:
1) Output a bam file of removed alignments
2) Look for mates of spurious alignments and either remove them or update SAM flag
3) To reduce memory usage, removed kept_brecs and instead added an iteration over the original BAM
